### PR TITLE
Fixed Player ID Bug

### DIFF
--- a/src/Marcel2508/CommandProcessor.php
+++ b/src/Marcel2508/CommandProcessor.php
@@ -21,7 +21,7 @@ class CommandProcessor {
 
     //DB LOGIC:
     private function getVaultContents($player,$vault){
-        $query = "SELECT * FROM `vaults` WHERE `player` = ".$player." AND `vault` = '".$this->plugin->db->escapeString($vault)."';";
+        $query = "SELECT * FROM `vaults` WHERE `player` = '".$player."' AND `vault` = '".$this->plugin->db->escapeString($vault)."';";
         $res = $this->plugin->db->query($query);
         if($res){
             
@@ -58,7 +58,7 @@ class CommandProcessor {
             return true;
         }
 
-        $playerId=$player->getId();
+        $playerId=$player->getUniqueId();
         //Creating Inventory
         $inventory = $this->inventorySpawner->getInventory($player,[$targetId,$vault,($targetId!==$playerId?$playerId:-1)],"Vault #".$vault);
         //Get Item Array from DB File
@@ -138,7 +138,7 @@ class CommandProcessor {
 
     private function clearVault(Player $player, int $targetId, int $vault):bool{
         $this->clearVaultContents($targetId,$vault);
-        $player->sendMessage($this->plugin->msg("§aCleared §b".($player->getId()!=$targetId?"players":"your")." vault content!"));
+        $player->sendMessage($this->plugin->msg("§aCleared §b".($player->getUniqueId()!=$targetId?"players":"your")." vault content!"));
         return true;
     }
 
@@ -181,7 +181,7 @@ class CommandProcessor {
     private function wipeVaults(Player $player,int $targetId){
         //TODO: REFACTOR 
         $this->wipePlayerVaults($targetId);
-        $player->sendMessage($this->plugin->msg("§aCleared all ".($player->getId()!=$targetId?" vaults of that player!":"your vaults!")));
+        $player->sendMessage($this->plugin->msg("§aCleared all ".($player->getUniqueId()!=$targetId?" vaults of that player!":"your vaults!")));
         return true;
     }
 
@@ -212,7 +212,7 @@ class CommandProcessor {
     //All commands begin with /pv
     private function playerCommand(Player $player, array $args) : bool{
         $argCount = count($args);
-        $playerId = $player->getId();
+        $playerId = $player->getUniqueId();
         if($argCount==0){
             if(!$this->hasRight($player,"pv.vault.use"))return true;
             //SHOW FIRST VAULT
@@ -290,7 +290,7 @@ class CommandProcessor {
     private function adminCommand(Player $player, array $args) : bool{
 
         $argCount = count($args);
-        $playerId = $player->getId();
+        $playerId = $player->getUniqueId();
         if($argCount<1){
             //SHOW FIRST VAULT
             $player->sendMessage($this->plugin->msg("§5Wrong command syntax! §dType /pv help for more info!"));
@@ -303,7 +303,7 @@ class CommandProcessor {
                 if($argCount==3){
                     $tPlayer = $this->plugin->getServer()->getPlayer($args[2]);
                     if($tPlayer){
-                        $tPlayerId = $tPlayer->getId();
+                        $tPlayerId = $tPlayer->getUniqueId();
                         if(strtolower($args[1])=="all"){
                             $this->wipeVaults($player,$tPlayerId);
                             return true;
@@ -376,7 +376,7 @@ class CommandProcessor {
                 if($argCount==2){
                     $tPlayer = $this->plugin->getServer()->getPlayer($args[1]);
                     if($tPlayer){
-                        $tPlayerId = $tPlayer->getId();
+                        $tPlayerId = $tPlayer->getUniqueId();
                         //PLAYER FOUND proceed
                         if(is_numeric($args[0])&&($intArg=intval($args[0]))>0){
                             //IF: Test for limit

--- a/src/Marcel2508/PlayerEvents.php
+++ b/src/Marcel2508/PlayerEvents.php
@@ -26,7 +26,7 @@ class PlayerEvents implements Listener {
 
     private function saveVault(ChestInventory $inventory, Player $player, int $vault, int $vaultPlayerId,int $vaultPlayerAdminId){
 
-        $playerId = $player->getId();
+        $playerId = $player->getUniqueId();
         $gamemode = $player->getGamemode();
         if($playerId===$vaultPlayerId||($vaultPlayerAdminId!=-1&&$vaultPlayerAdminId==$playerId)){
             $queryList = "DELETE FROM `vaults` WHERE `player` = '".$vaultPlayerId."' AND `vault` = '".$vault."';";

--- a/src/Marcel2508/PlayerVaults.php
+++ b/src/Marcel2508/PlayerVaults.php
@@ -31,7 +31,8 @@ class PlayerVaults extends PluginBase implements Listener,CommandExecutor{
         $this->settings = $this->getConfig()->getAll();
 
         $this->db = new SQLite3($this->getDataFolder() . "db.bin");
-        $this->db->exec("CREATE TABLE IF NOT EXISTS vaults (player integer, vault integer, gamemode integer, itemid integer, amount integer, meta integer,nbt BLOB, slot integer); ");        //CREATE INDEX IF NOT EXISTS playerInventoriesIndex ON playerInventories (player);
+        //THIS WILL NEED THE SERVERS TO DELETE THE DATABASE FILE IN ORDER TO BE RECREATED...
+        $this->db->exec("CREATE TABLE IF NOT EXISTS vaults (player text, vault integer, gamemode integer, itemid integer, amount integer, meta integer,nbt BLOB, slot integer); ");        //CREATE INDEX IF NOT EXISTS playerInventoriesIndex ON playerInventories (player);
         
         $this->commandProcessor = new CommandProcessor($this);
         $this->getServer()->getPluginManager()->registerEvents(new PlayerEvents($this), $this);


### PR DESCRIPTION
Hey, 
my original Version had a important Bug. I used the wrong player ID ($player->getId()) instead of $player->getUniqeId();

The getId() method will return different Id's every session. Thats the reason why I changed it.

I already changed this issue in the Past for the original Leet Plugin, but I forgot to push it to github back then.

This means, that server owners would have to manually remove the already existing Databse file, in order to generate a new one with player column datatype string instead of int ... 

!! I haven't tested my changes yet. Please make sure they work before merging this pull request... !!